### PR TITLE
Undisposed Graphics object

### DIFF
--- a/src/Static/Graphics.cs
+++ b/src/Static/Graphics.cs
@@ -10,9 +10,11 @@ namespace JuliusSweetland.OptiKey.Static
         {
             get
             {
-                var g = System.Drawing.Graphics.FromHwnd(IntPtr.Zero);
-                var desktop = g.GetHdc();
-                return PInvoke.GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSX);
+                using(var g = System.Drawing.Graphics.FromHwnd(IntPtr.Zero))
+                {
+                    var desktop = g.GetHdc();
+                    return PInvoke.GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSX);
+                }
             }
         }
         
@@ -25,9 +27,11 @@ namespace JuliusSweetland.OptiKey.Static
         {
             get
             {
-                var g = System.Drawing.Graphics.FromHwnd(IntPtr.Zero);
-                var desktop = g.GetHdc();
-                return PInvoke.GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSY);
+                using(var g = System.Drawing.Graphics.FromHwnd(IntPtr.Zero))
+                {
+                    var desktop = g.GetHdc();
+                    return PInvoke.GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSY);
+                }
             }
         }
         


### PR DESCRIPTION
Noticed it while I was cruising through the source, probably no biggie but it was in there anyway.
g/Graphics is a disposable object backed by native GDI objects.