### PR TITLE
Fixed crash on startup

### DIFF
--- a/src/Static/DiagnosticInfo.cs
+++ b/src/Static/DiagnosticInfo.cs
@@ -228,8 +228,16 @@ namespace JuliusSweetland.OptiKey.Static
         {
             get
             {
-                var uacKey = Registry.LocalMachine.OpenSubKey(uacRegistryKey, false);
-                return uacKey.GetValue(uacRegistryValue).Equals(1);
+                try
+                {
+                    var uacKey = Registry.LocalMachine.OpenSubKey(uacRegistryKey, false);
+                    return uacKey.GetValue(uacRegistryValue).Equals(1);
+                }
+                catch(NullReferenceException)
+                {
+                    // if there is no key, then it must not be enabled
+                    return false;
+                }
             }
         }
     }


### PR DESCRIPTION
Cause was from EnableLUA registry value not existing.

I'm not sure how common of a configuration this is, but OptiKey crashed on startup.

Turns out my machine does not have an EnableLUA registry value.

Simple solution was a try..catch for a NullReferenceException. If the value does not exist, UAC must not be enabled, so I just returned false.

Runs on my machine just fine now.