### PR TITLE
Found an untranslated string

### DIFF
--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -143,15 +143,6 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to American English.
-        /// </summary>
-        public static string ENGLISH_US {
-            get {
-                return ResourceManager.GetString("ENGLISH_US", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Android Dark.
         /// </summary>
         public static string ANDROID_DARK {
@@ -262,15 +253,6 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to British English.
-        /// </summary>
-        public static string ENGLISH_UK {
-            get {
-                return ResourceManager.GetString("ENGLISH_UK", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Calibration aborted with message: &apos;{0}&apos;.
         /// </summary>
         public static string CALIBRATION_ABORT_MESSAGE {
@@ -331,15 +313,6 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string CALIBRATION_SUCCESS {
             get {
                 return ResourceManager.GetString("CALIBRATION_SUCCESS", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Canadian English.
-        /// </summary>
-        public static string ENGLISH_CANADA {
-            get {
-                return ResourceManager.GetString("ENGLISH_CANADA", resourceCulture);
             }
         }
         
@@ -752,6 +725,33 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to English (Canada).
+        /// </summary>
+        public static string ENGLISH_CANADA {
+            get {
+                return ResourceManager.GetString("ENGLISH_CANADA", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to English (UK).
+        /// </summary>
+        public static string ENGLISH_UK {
+            get {
+                return ResourceManager.GetString("ENGLISH_UK", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to English (US).
+        /// </summary>
+        public static string ENGLISH_US {
+            get {
+                return ResourceManager.GetString("ENGLISH_US", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ENTER.
         /// </summary>
         public static string ENTER {
@@ -959,7 +959,7 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to French (France).
+        ///   Looks up a localized string similar to Français (France).
         /// </summary>
         public static string FRENCH_FRANCE {
             get {
@@ -2844,6 +2844,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string TOBII_EYEX {
             get {
                 return ResourceManager.GetString("TOBII_EYEX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Calibration completed, or possibly cancelled, but everything is working again!.
+        /// </summary>
+        public static string TOBII_EYEX_CALIBRATION_SUCCESS {
+            get {
+                return ResourceManager.GetString("TOBII_EYEX_CALIBRATION_SUCCESS", resourceCulture);
             }
         }
         

--- a/src/Properties/Resources.fr-FR.resx
+++ b/src/Properties/Resources.fr-FR.resx
@@ -1171,4 +1171,7 @@ Vous pouvez éteindre la vérification de nouvelle version dans la fenêtre de p
   <data name="UPPER_CASE" xml:space="preserve">
     <value>Tout en majuscule</value>
   </data>
+  <data name="TOBII_EYEX_CALIBRATION_SUCCESS" xml:space="preserve">
+    <value>Le calibrage est terminé, ou peut-être annulé, mais tout fonctionne normallement !</value>
+  </data>
 </root>

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -145,9 +145,6 @@ DICTIONARY</value>
   <data name="ALT" xml:space="preserve">
     <value>ALT</value>
   </data>
-  <data name="ENGLISH_US" xml:space="preserve">
-    <value>English (US)</value>
-  </data>
   <data name="ANDROID_DARK" xml:space="preserve">
     <value>Android Dark</value>
   </data>
@@ -186,9 +183,6 @@ WORD</value>
   <data name="BREAK" xml:space="preserve">
     <value>BREAK</value>
   </data>
-  <data name="ENGLISH_UK" xml:space="preserve">
-    <value>English (UK)</value>
-  </data>
   <data name="CALIBRATION_ABORT_MESSAGE" xml:space="preserve">
     <value>Calibration aborted with message: '{0}'</value>
   </data>
@@ -210,9 +204,6 @@ Are you sure you would like to re-calibrate?</value>
   </data>
   <data name="CALIBRATION_SUCCESS" xml:space="preserve">
     <value>Calibration success! Accuracy (Avg Error Degree = {0})</value>
-  </data>
-  <data name="ENGLISH_CANADA" xml:space="preserve">
-    <value>English (Canada)</value>
   </data>
   <data name="CANCEL" xml:space="preserve">
     <value>CANCEL</value>
@@ -358,6 +349,15 @@ ARROW</value>
   <data name="END" xml:space="preserve">
     <value>END</value>
   </data>
+  <data name="ENGLISH_CANADA" xml:space="preserve">
+    <value>English (Canada)</value>
+  </data>
+  <data name="ENGLISH_UK" xml:space="preserve">
+    <value>English (UK)</value>
+  </data>
+  <data name="ENGLISH_US" xml:space="preserve">
+    <value>English (US)</value>
+  </data>
   <data name="ENTER" xml:space="preserve">
     <value>ENTER</value>
   </data>
@@ -434,7 +434,7 @@ UP</value>
     <value>Font weight:</value>
   </data>
   <data name="FRENCH_FRANCE" xml:space="preserve">
-    <value>French (France)</value>
+    <value>Français (France)</value>
   </data>
   <data name="FULL_DOCK_THICKNESS_LABEL" xml:space="preserve">
     <value>Full dock thickness (as % of screen):</value>
@@ -505,6 +505,9 @@ UP &amp; RIGHT</value>
     <value>JUMP
 UP</value>
   </data>
+  <data name="KEY_CASE_LABEL" xml:space="preserve">
+    <value>Key text transformation:</value>
+  </data>
   <data name="KEY_FIXATION_TIME_TO_COMPLETE_LABEL" xml:space="preserve">
     <value>Key fixation time to complete (ms):</value>
   </data>
@@ -562,6 +565,9 @@ DOWN/UP</value>
   </data>
   <data name="LOOK" xml:space="preserve">
     <value>Look</value>
+  </data>
+  <data name="LOWER_CASE" xml:space="preserve">
+    <value>All in lower case</value>
   </data>
   <data name="MAGNETIC_CURSOR_SPLIT_WITH_NEWLINE" xml:space="preserve">
     <value>MAGNETIC
@@ -1086,8 +1092,14 @@ POSITION</value>
   <data name="TIME_UNTIL_POINT_BECOMES_IRRELEVENT_LABEL" xml:space="preserve">
     <value>Time until point becomes irrelevent (ms):</value>
   </data>
+  <data name="TITLE_CASE" xml:space="preserve">
+    <value>Words are capitalized</value>
+  </data>
   <data name="TOBII_EYEX" xml:space="preserve">
     <value>Tobii EyeX</value>
+  </data>
+  <data name="TOBII_EYEX_CALIBRATION_SUCCESS" xml:space="preserve">
+    <value>Calibration completed, or possibly cancelled, but everything is working again!</value>
   </data>
   <data name="TOBII_EYEX_ENGINE_NOT_FOUND" xml:space="preserve">
     <value>Tobii EyeX Engine cannot be found. Please install the EyeX Engine and try again.</value>
@@ -1141,6 +1153,9 @@ ARROW</value>
   <data name="UPDATE_AVAILABLE" xml:space="preserve">
     <value>UPDATE AVAILABLE!</value>
   </data>
+  <data name="UPPER_CASE" xml:space="preserve">
+    <value>All in upper case</value>
+  </data>
   <data name="URL_DOWNLOAD_PROMPT" xml:space="preserve">
     <value>Please visit www.optikey.org to download latest version ({0})
 You can turn off update checks from the Management Console (ALT + M).</value>
@@ -1180,17 +1195,5 @@ You can turn off update checks from the Management Console (ALT + M).</value>
   </data>
   <data name="YES" xml:space="preserve">
     <value>YES</value>
-  </data>
-  <data name="KEY_CASE_LABEL" xml:space="preserve">
-    <value>Key text transformation:</value>
-  </data>
-  <data name="TITLE_CASE" xml:space="preserve">
-    <value>Words are capitalized</value>
-  </data>
-  <data name="LOWER_CASE" xml:space="preserve">
-    <value>All in lower case</value>
-  </data>
-  <data name="UPPER_CASE" xml:space="preserve">
-    <value>All in upper case</value>
   </data>
 </root>

--- a/src/Services/TobiiEyeXCalibrationService.cs
+++ b/src/Services/TobiiEyeXCalibrationService.cs
@@ -27,7 +27,7 @@ namespace JuliusSweetland.OptiKey.Services
                 {
                     if (e.IsValid && e.Value == EyeTrackingDeviceStatus.Tracking)
                     {
-                        taskCompletionSource.SetResult("Calibration completed, or possibly cancelled, but everything is working again!");
+                        taskCompletionSource.SetResult(Resources.TOBII_EYEX_CALIBRATION_SUCCESS);
                     }
                 };
             }


### PR DESCRIPTION
I'vd added a resource key for "calibration complete" message (Tobii EyeX).
Sorry for that, but my Visual Studio automatically reorder keys in the english resx file (ENGLISH_IK, ENGLISH_CA, ENGLISH_US, KEY_CASE_LABEL, TITLE_CASE, LOWER_CASE, UPPER_CASE)

Just pay attention to a proposal in FRANCE_FRENCH: I think we should provide default locale names in the locale language, to allow user detect their own langage, even if they're not confident with english.

Sorry for not having seen this missing key before. To me the 2.1.0 version is ready for french. I've accepted the french values on trensiflex because no one avec made any change since a week.