### PR TITLE
Capture part of behavior AttachServiceEventHandlers on MainViewModel and of ManagementViewModel

### DIFF
--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -45,6 +45,7 @@
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Prism, Version=6.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Prism.Core.6.0.1\lib\net45\Prism.dll</HintPath>
@@ -77,6 +78,7 @@
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\WhenRaiseToastNotification.cs" />
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\WhenSelectionMode.cs" />
     <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\ManagementViewModelTestBase.cs" />
+    <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenCancelCommand.cs" />
     <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenChangesRequireRestart.cs" />
     <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenConstruct.cs" />
     <Compile Include="UI\ViewModels\Management\WordsViewModelTests.cs" />

--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenCancelCommand.cs" />
     <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenChangesRequireRestart.cs" />
     <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenConstruct.cs" />
+    <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenOkCommand.cs" />
     <Compile Include="UI\ViewModels\Management\WordsViewModelTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -82,6 +82,8 @@
     <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenChangesRequireRestart.cs" />
     <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenConstruct.cs" />
     <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenOkCommand.cs" />
+    <Compile Include="UI\ViewModels\Management\DictionaryViewModelSpecifications\DictionaryViewModelTestBase.cs" />
+    <Compile Include="UI\ViewModels\Management\DictionaryViewModelSpecifications\WhenConstruct.cs" />
     <Compile Include="UI\ViewModels\Management\WordsViewModelTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Services\KeyboardOutputServiceTests.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\MainViewModelTestBase.cs" />
+    <Compile Include="UI\ViewModels\MainViewModelSpecifications\WhenAttachServiceEventHandlers.cs" />
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\WhenConstruct.cs" />
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\WhenFireKeySelectionEvent.cs" />
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\WhenPointToKeyValueMap.cs" />

--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -45,6 +45,7 @@
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PresentationFramework" />
     <Reference Include="Prism, Version=6.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Prism.Core.6.0.1\lib\net45\Prism.dll</HintPath>
       <Private>True</Private>
@@ -75,6 +76,8 @@
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\WhenPointToKeyValueMap.cs" />
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\WhenRaiseToastNotification.cs" />
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\WhenSelectionMode.cs" />
+    <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\ManagementViewModelTestBase.cs" />
+    <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenConstruct.cs" />
     <Compile Include="UI\ViewModels\Management\WordsViewModelTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\WhenRaiseToastNotification.cs" />
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\WhenSelectionMode.cs" />
     <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\ManagementViewModelTestBase.cs" />
+    <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenChangesRequireRestart.cs" />
     <Compile Include="UI\ViewModels\ManagementViewModelSpecifications\WhenConstruct.cs" />
     <Compile Include="UI\ViewModels\Management\WordsViewModelTests.cs" />
   </ItemGroup>

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/MainViewModelTestBase.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/MainViewModelTestBase.cs
@@ -22,6 +22,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         protected Mock<IMouseOutputService> MouseOutputService { get; private set; }
         protected Mock<ISuggestionStateService> SuggestionService { get; private set; }
         protected List<INotifyErrors> ErrorNotifyingServices { get; private set; }
+        protected bool IsKeySelectionEventHandlerCalled { get; private set; }
+        protected bool IsPointSelectionEventHandlerCalled { get; private set; }
 
         protected virtual bool ShouldConstruct { get { return true; } }
 
@@ -45,10 +47,15 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
             ErrorNotifyingServices = new List<INotifyErrors>();
 
             if(ShouldConstruct)
+            {
                 MainViewModel = new MainViewModel(AudioService.Object, CalibrationService.Object, DictionaryService.Object,
-                   KeyStateService.Object, SuggestionService.Object, CapturingStateManager.Object, LastMouseActionStateManager.Object,
-                   InputService.Object, KeyboardOutputService.Object, MouseOutputService.Object, MainWindowManipulationService.Object,
-                   ErrorNotifyingServices);
+                    KeyStateService.Object, SuggestionService.Object, CapturingStateManager.Object, LastMouseActionStateManager.Object,
+                    InputService.Object, KeyboardOutputService.Object, MouseOutputService.Object, MainWindowManipulationService.Object,
+                    ErrorNotifyingServices);
+
+                MainViewModel.KeySelection += (s, e) => IsKeySelectionEventHandlerCalled = true;
+                MainViewModel.PointSelection += (s, e) => IsPointSelectionEventHandlerCalled = true;
+            }
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenAttachServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenAttachServiceEventHandlers.cs
@@ -3,11 +3,11 @@ using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Properties;
 using JuliusSweetland.OptiKey.Services;
 using Moq;
-using System.Linq;
 using NUnit.Framework;
 using System;
-using System.Windows;
 using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
 
 namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifications
 {

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenAttachServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenAttachServiceEventHandlers.cs
@@ -1,0 +1,217 @@
+﻿using JuliusSweetland.OptiKey.Enums;
+using JuliusSweetland.OptiKey.Models;
+using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.Services;
+using Moq;
+using System.Linq;
+using NUnit.Framework;
+using System;
+using System.Windows;
+
+namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifications
+{
+    public class WhenAttachServiceEventHandlers : MainViewModelTestBase
+    {
+        protected Mock<INotifyErrors> NotifyErrorsMock { get; set; }
+        protected NotificationEventArgs NotificationEvent { get; private set; }
+
+        protected override void Arrange()
+        {
+            base.Arrange();
+
+            NotifyErrorsMock = new Mock<INotifyErrors>();
+            ErrorNotifyingServices.Add(NotifyErrorsMock.Object);
+
+            MainViewModel.ToastNotification += (s, e) => NotificationEvent = e;
+        }
+
+        protected override void Act()
+        {
+            MainViewModel.AttachServiceEventHandlers();
+        }
+
+        [Test]
+        public void ThenAnErrorEventHandlerShouldBeAttached()
+        {
+            var ex = new Exception("dummy");
+            NotifyErrorsMock.Raise(e => e.Error += null, this, ex);
+
+            InputService.Verify(s => s.RequestSuspend(), Times.Once());
+            AudioService.Verify(s => s.PlaySound(Settings.Default.ErrorSoundFile, Settings.Default.ErrorSoundVolume), Times.Once());
+
+            Assert.IsNotNull(NotificationEvent);
+            Assert.AreEqual(Resources.CRASH_TITLE, NotificationEvent.Title);
+            Assert.AreEqual(ex.Message, NotificationEvent.Content);
+            Assert.AreEqual(NotificationTypes.Error, NotificationEvent.NotificationType);
+        }
+
+        [Test]
+        public void ThenPointsPerSecondEventHandlerShouldBeAttachedToInputService()
+        {
+            InputService.Raise(s => s.PointsPerSecond += null, this, 123);
+            Assert.AreEqual(123, MainViewModel.PointsPerSecond);
+        }
+
+        [Test]
+        public void ThenA_SelectionProgressEventHandlerShouldBeAttachedToInputService()
+        {
+
+        }
+
+        [Test]
+        public void ThenA_SelectionEventHandlerShouldBeAttachedToInputService()
+        {
+
+        }
+
+        [Test]
+        public void ThenA_SelectionResultEventHandlerShouldBeAttachedToInputService()
+        {
+
+        }
+
+        public void ThenPointToKeyValueMapShouldBeSetOnInputService()
+        {
+
+        }
+
+        public void ThenSelectionModeShouldBeSetOnInputService()
+        {
+
+        }
+    }
+
+    [TestFixture]
+    public class WhenAttachServiceEventHandlersGivenMouseMagneticCursorKeyDownAndSleepKeyUp : WhenAttachServiceEventHandlers
+    {
+        protected override void Arrange()
+        {
+            base.Arrange();
+
+            var keyDownStates = new NotifyingConcurrentDictionary<KeyValue, KeyDownStates>();
+            keyDownStates[KeyValues.MouseMagneticCursorKey] = new NotifyingProxy<KeyDownStates>(KeyDownStates.Down);
+            keyDownStates[KeyValues.SleepKey] = new NotifyingProxy<KeyDownStates>(KeyDownStates.Up);
+            KeyStateService.Setup(s => s.KeyDownStates).Returns(keyDownStates);
+        }
+
+        [Test]
+        public void ThenA_CurrentPositionEventHandlerShouldBeAttachedToInputService()
+        {
+            var point = new Point(27, 10);
+            var keyValue = new KeyValue();
+            InputService.Raise(s => s.CurrentPosition += null, this, new Tuple<Point, KeyValue?>(point, keyValue));
+
+            Assert.AreEqual(point, MainViewModel.CurrentPositionPoint);
+            Assert.AreEqual(keyValue, MainViewModel.CurrentPositionKey);
+
+            MouseOutputService.Verify(s => s.MoveTo(point), Times.Once());
+        }
+    }
+
+    [TestFixture]
+    public class WhenAttachServiceEventHandlersGivenMouseMagneticCursorKeyUp : WhenAttachServiceEventHandlers
+    {
+        protected override void Arrange()
+        {
+            base.Arrange();
+
+            var keyDownStates = new NotifyingConcurrentDictionary<KeyValue, KeyDownStates>();
+            keyDownStates[KeyValues.MouseMagneticCursorKey] = new NotifyingProxy<KeyDownStates>(KeyDownStates.Up);
+            KeyStateService.Setup(s => s.KeyDownStates).Returns(keyDownStates);
+        }
+
+        [Test]
+        public void ThenA_CurrentPositionEventHandlerShouldBeAttachedToInputService()
+        {
+            var point = new Point(27, 10);
+            var keyValue = new KeyValue();
+            InputService.Raise(s => s.CurrentPosition += null, this, new Tuple<Point, KeyValue?>(point, keyValue));
+
+            Assert.AreEqual(point, MainViewModel.CurrentPositionPoint);
+            Assert.AreEqual(keyValue, MainViewModel.CurrentPositionKey);
+
+            MouseOutputService.Verify(s => s.MoveTo(point), Times.Never());
+        }
+    }
+
+    [TestFixture]
+    public class WhenAttachServiceEventHandlersGivenEmptyProgress : WhenAttachServiceEventHandlers
+    {
+        protected NotifyingConcurrentDictionary<KeyValue, double> KeySelectionProgress { get; set; }
+
+        protected override void Arrange()
+        {
+            base.Arrange();
+
+            KeySelectionProgress = new NotifyingConcurrentDictionary<KeyValue, double>();
+            KeySelectionProgress[new KeyValue()] = new NotifyingProxy<double>(123);
+            KeyStateService.Setup(s => s.KeySelectionProgress)
+                .Returns(KeySelectionProgress);
+        }
+
+        [Test]
+        public void ThenSelectionProgressShouldBeReset()
+        {
+            InputService.Raise(s => s.SelectionProgress += null, this, new Tuple<PointAndKeyValue?, double>(null, 0));
+
+            Assert.IsNull(MainViewModel.PointSelectionProgress);
+
+            KeySelectionProgress.Keys
+                .ToList()
+                .ForEach(k => Assert.AreEqual(default(double), KeySelectionProgress[k].Value));
+        }
+    }
+
+    [TestFixture]
+    public class WhenAttachServiceEventHandlersGivenProgressNotEmptyAndSelectionModeKey : WhenAttachServiceEventHandlers
+    {
+        protected NotifyingConcurrentDictionary<KeyValue, double> KeySelectionProgress { get; set; }
+        protected KeyValue KeyValueToAssert { get; set; }
+
+        protected override void Arrange()
+        {
+            base.Arrange();
+
+            MainViewModel.SelectionMode = SelectionModes.Key;
+
+            KeyValueToAssert = new KeyValue();
+            KeySelectionProgress = new NotifyingConcurrentDictionary<KeyValue, double>();
+            KeySelectionProgress[KeyValueToAssert] = new NotifyingProxy<double>(123);
+            KeyStateService.Setup(s => s.KeySelectionProgress)
+                .Returns(KeySelectionProgress);
+        }
+
+        [Test]
+        public void ThenKeySelectionProgressOnKeyStateServiceShouldBeSet()
+        {
+            InputService.Raise(s => s.SelectionProgress += null, this, new Tuple<PointAndKeyValue?, double>(
+                new PointAndKeyValue(new Point(), KeyValueToAssert), 14));
+
+            Assert.AreEqual(14, KeySelectionProgress[KeyValueToAssert].Value);
+        }
+    }
+
+    [TestFixture]
+    public class WhenAttachServiceEventHandlersGivenProgressNotEmptyAndSelectionModePoint : WhenAttachServiceEventHandlers
+    {
+        protected override void Arrange()
+        {
+            base.Arrange();
+
+            MainViewModel.SelectionMode = SelectionModes.Point;
+        }
+
+        [Test]
+        public void ThenPointSelectionProgressShouldBeSet()
+        {
+            var pointAndKeyValue = new PointAndKeyValue(new Point(), new KeyValue());
+
+            InputService.Raise(s => s.SelectionProgress += null, this, new Tuple<PointAndKeyValue?, double>(
+                pointAndKeyValue, 83));
+
+            Assert.IsNotNull(MainViewModel.PointSelectionProgress);
+            Assert.AreEqual(pointAndKeyValue.Point, MainViewModel.PointSelectionProgress.Item1);
+            Assert.AreEqual(83, MainViewModel.PointSelectionProgress.Item2);
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenFireKeySelectionEvent.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenFireKeySelectionEvent.cs
@@ -8,13 +8,6 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
     public class WhenFireKeySelectionEventGivenKeySelectionEventHandler : MainViewModelTestBase
     {
         protected KeyValue KeyValue { get { return new KeyValue { FunctionKey = FunctionKeys.Break, String = "Coffee" }; } }
-        protected bool IsKeySelectionEventHandlerCalled { get; private set; }
-
-        protected override void Arrange()
-        {
-            base.Arrange();
-            MainViewModel.KeySelection += (s, e) => IsKeySelectionEventHandlerCalled = true;
-        }
 
         protected override void Act()
         {

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/Management/DictionaryViewModelSpecifications/DictionaryViewModelTestBase.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/Management/DictionaryViewModelSpecifications/DictionaryViewModelTestBase.cs
@@ -1,0 +1,24 @@
+﻿using JuliusSweetland.OptiKey.Services;
+using JuliusSweetland.OptiKey.UI.ViewModels.Management;
+using Moq;
+
+namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.Management.DictionaryViewModelSpecifications
+{
+    public abstract class DictionaryViewModelTestBase : TestBase
+    {
+        protected DictionaryViewModel DictionaryViewModel { get; set; }
+        protected Mock<IDictionaryService> DictionaryService { get; private set; }
+
+        protected virtual bool ShouldConstruct { get { return true; } }
+
+        protected override void Arrange()
+        {
+            DictionaryService = new Mock<IDictionaryService>();
+
+            if (ShouldConstruct)
+            {
+                DictionaryViewModel = new DictionaryViewModel(DictionaryService.Object);
+            }
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/Management/DictionaryViewModelSpecifications/WhenConstruct.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/Management/DictionaryViewModelSpecifications/WhenConstruct.cs
@@ -1,0 +1,50 @@
+﻿using JuliusSweetland.OptiKey.Models;
+using JuliusSweetland.OptiKey.UI.ViewModels.Management;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.Management.DictionaryViewModelSpecifications
+{
+    [TestFixture]
+    public class WhenConstruct : DictionaryViewModelTestBase
+    {
+        protected override bool ShouldConstruct
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        protected List<DictionaryEntry> DictionaryEntries { get; set; }
+
+        protected override void Arrange()
+        {
+            base.Arrange();
+
+            DictionaryEntries = new List<DictionaryEntry> { new DictionaryEntry(), new DictionaryEntry() };
+
+            DictionaryService.Setup(r => r.GetAllEntries())
+                .Returns(DictionaryEntries);
+        }
+
+        protected override void Act()
+        {
+            DictionaryViewModel = new DictionaryViewModel(DictionaryService.Object);
+        }
+
+        [Test]
+        public void ThenCommandsShouldBeConstructed()
+        {
+            Assert.IsNotNull(DictionaryViewModel.AddCommand);
+            Assert.IsNotNull(DictionaryViewModel.ToggleDeleteCommand);
+        }
+
+        [Test]
+        public void ThenEntriesShouldBeLoaded()
+        {
+            Assert.IsNotNull(DictionaryViewModel.Entries);
+            Assert.AreEqual(DictionaryEntries.Count, DictionaryViewModel.Entries.Count);
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/ManagementViewModelTestBase.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/ManagementViewModelTestBase.cs
@@ -1,0 +1,26 @@
+﻿using JuliusSweetland.OptiKey.Services;
+using JuliusSweetland.OptiKey.UI.ViewModels;
+using Moq;
+
+namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpecifications
+{
+    public abstract class ManagementViewModelTestBase : TestBase
+    {
+        protected ManagementViewModel ManagementViewModel { get; set; }
+        protected Mock<IAudioService> AudioService { get; private set; }
+        protected Mock<IDictionaryService> DictionaryService { get; private set; }
+
+        protected virtual bool ShouldConstruct { get { return true; } }
+
+        protected override void Arrange()
+        {
+            AudioService = new Mock<IAudioService>();
+            DictionaryService = new Mock<IDictionaryService>();
+
+            if (ShouldConstruct)
+            {
+                ManagementViewModel = new ManagementViewModel(AudioService.Object, DictionaryService.Object);
+            }
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenCancelCommand.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenCancelCommand.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+using System.Windows;
+
+namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpecifications
+{
+    [TestFixture]
+    public class WhenCancelCommand : ManagementViewModelTestBase
+    {
+        protected Window Window { get; private set; }
+        protected bool IsWindowClosed { get; private set; }
+
+        protected override void Arrange()
+        {
+            base.Arrange();
+            Window = new Window();
+            Window.Closed += (s, e) => IsWindowClosed = true;
+        }
+
+        protected override void Act()
+        {
+            ManagementViewModel.CancelCommand.Execute(Window);
+        }
+
+        [RequiresSTA]
+        [Test]
+        public void ThenWindowShouldBeClosed()
+        {
+            Assert.IsTrue(IsWindowClosed);
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenChangesRequireRestart.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenChangesRequireRestart.cs
@@ -1,0 +1,42 @@
+﻿using JuliusSweetland.OptiKey.Properties;
+using NUnit.Framework;
+using System;
+
+namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpecifications
+{
+    [TestFixture]
+    public class WhenChangesRequireRestart : ManagementViewModelTestBase
+    {
+        protected bool Result { get; private set; }
+
+        protected override void Arrange()
+        {
+            base.Arrange();
+            Settings.Default.Debug = false;
+            ManagementViewModel.VisualsViewModel.ConversationOnlyMode = false;
+            Settings.Default.ConversationOnlyMode = false;
+        }
+
+        [Test]
+        public void GivenOtherViewModelRequiresRestart()
+        {
+            Settings.Default.Debug = true;
+            Assert.IsTrue(ManagementViewModel.ChangesRequireRestart);
+        }
+
+        [Test]
+        public void GivenPointingAndSelectingViewModelRequiresRestart()
+        {
+            Settings.Default.MultiKeySelectionMaxDuration = TimeSpan.FromSeconds(42);
+            Assert.IsTrue(ManagementViewModel.ChangesRequireRestart);
+        }
+
+        [Test]
+        public void GivenVisualsViewModelRequiresRestart()
+        {
+            ManagementViewModel.VisualsViewModel.ConversationOnlyMode = false;
+            Settings.Default.ConversationOnlyMode = true;
+            Assert.IsTrue(ManagementViewModel.ChangesRequireRestart);
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenConstruct.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenConstruct.cs
@@ -1,0 +1,40 @@
+﻿using JuliusSweetland.OptiKey.UI.ViewModels;
+using NUnit.Framework;
+
+namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpecifications
+{
+    [TestFixture]
+    public class WhenConstruct : ManagementViewModelTestBase
+    {
+        protected override bool ShouldConstruct
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        protected override void Act()
+        {
+            ManagementViewModel = new ManagementViewModel(AudioService.Object, DictionaryService.Object);
+        }
+
+        [Test]
+        public void ThenChildViewModelShouldBeConstructed()
+        {
+            Assert.IsNotNull(ManagementViewModel.DictionaryViewModel);
+            Assert.IsNotNull(ManagementViewModel.OtherViewModel);
+            Assert.IsNotNull(ManagementViewModel.PointingAndSelectingViewModel);
+            Assert.IsNotNull(ManagementViewModel.SoundsViewModel);
+            Assert.IsNotNull(ManagementViewModel.VisualsViewModel);
+            Assert.IsNotNull(ManagementViewModel.WordsViewModel);
+        }
+
+        public void ThenInteractionRequestsAndCommandsShouldBeConstructed()
+        {
+            Assert.IsNotNull(ManagementViewModel.ConfirmationRequest);
+            Assert.IsNotNull(ManagementViewModel.OkCommand);
+            Assert.IsNotNull(ManagementViewModel.CancelCommand);
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenConstruct.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenConstruct.cs
@@ -30,6 +30,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpe
             Assert.IsNotNull(ManagementViewModel.WordsViewModel);
         }
 
+        [Test]
         public void ThenInteractionRequestsAndCommandsShouldBeConstructed()
         {
             Assert.IsNotNull(ManagementViewModel.ConfirmationRequest);

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenOkCommand.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenOkCommand.cs
@@ -1,0 +1,52 @@
+﻿using JuliusSweetland.OptiKey.Properties;
+using NUnit.Framework;
+using System.Windows;
+
+namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpecifications
+{
+    public abstract class WhenOkCommand : ManagementViewModelTestBase
+    {
+        protected Window Window { get; private set; }
+        protected bool IsWindowClosed { get; private set; }
+
+        protected override void Arrange()
+        {
+            base.Arrange();
+            Window = new Window();
+            Window.Closed += (s, e) => IsWindowClosed = true;
+        }
+
+        protected override void Act()
+        {
+            ManagementViewModel.OkCommand.Execute(Window);
+        }
+    }
+
+    [TestFixture]
+    public class WhenOkCommandGivenRestartRequired : WhenOkCommand
+    {
+        protected override void Arrange()
+        {
+            base.Arrange();
+            Settings.Default.Debug = true;
+        }
+
+        [RequiresSTA]
+        [Test]
+        public void ThenWindowShouldNotBeClosed()
+        {
+            Assert.IsFalse(IsWindowClosed);
+        }
+    }
+
+    [TestFixture]
+    public class WhenOkCommandGivenRestartNotRequired : WhenOkCommand
+    {
+        [RequiresSTA]
+        [Test]
+        public void ThenWindowShouldBeClosed()
+        {
+            Assert.IsTrue(IsWindowClosed);
+        }
+    }
+}


### PR DESCRIPTION
MainViewModel.HandleFunctionKeySelectionResult is not tested, I don't expect i'll have the courage anytime soon to cover that by tests :)

If you think this important however, you could perhaps point out the most important FunctionKeys cases, which would have the biggest impact when broken.

ManagementViewModel instantiates other view models, so I cannot properly unit test it in isolation.
I think you could benefit from working with an IoC container, but for now I'm not suggesting to do any big refactors until more of the application is covered by tests.